### PR TITLE
Improved readability for promotion messages

### DIFF
--- a/bot.lua
+++ b/bot.lua
@@ -5252,7 +5252,7 @@ commands["set"] = {
 									color = role.color,
 									title = "Promotion!",
 									thumbnail = { url = member.user.avatarURL },
-									description = "**" .. member.name .. "** is now a(n) `" .. string.upper(role.name) .. "`.",
+									description = "**" .. member.name .. "** is now " .. ((not not string.match(string.upper(role.name)), '^[AEIOU]')) and ' an ' or ' a ' ) .. `" .. string.upper(role.name) .. "`.",
 									footer = { text = "Set by " .. message.member.name }
 								}
 							}

--- a/bot.lua
+++ b/bot.lua
@@ -5252,7 +5252,7 @@ commands["set"] = {
 									color = role.color,
 									title = "Promotion!",
 									thumbnail = { url = member.user.avatarURL },
-									description = "**" .. member.name .. "** is now " .. ((not not string.match(string.upper(role.name)), '^[AEIOU]')) and ' an ' or ' a ' ) .. `" .. string.upper(role.name) .. "`.",
+									description = "**" .. member.name .. "** is now " .. (string.find(role.name, "^[AEIOUaeiou]") and "a" or "an") .. " `" .. string.upper(role.name) .. "`.",
 									footer = { text = "Set by " .. message.member.name }
 								}
 							}


### PR DESCRIPTION
Changed the message (which is displayed when someone get promoted) to a more readable format 

The changes can be summarized as follows

```diff
- Seniru is now a(n) `DEVELOPER`.

@@ - Changes into  - @@

+ Seniru is now a DEVELOPER.
+ Seniru is now an ARTIST.

```
