### PR TITLE
Allow DM commands

### DIFF
--- a/bot.lua
+++ b/bot.lua
@@ -5293,7 +5293,7 @@ commands["gcmd"] = {
 
 			if channelLevel then
 				channelLevel = tonumber(channelLevel)
-				if channelLevel < 4 then
+				if channelLevel < 3 then
 					if authLevel then
 						authLevel = tonumber(authLevel)
 						if authLevel < 3 then

--- a/bot.lua
+++ b/bot.lua
@@ -4506,8 +4506,6 @@ commands["lua"] = {
 				assert((msg.channel.id ~= channels["commu"] and msg.channel.id ~= channels["modules"]), "Message deletion denied.")
 
 				if message.channel.type == 1 then -- dms
-					assert(msg.author.id == client.user.id, "You can only delete Modulo's messages in DMs.")
-
 					msg:delete()
 					return
 				end
@@ -4789,7 +4787,6 @@ commands["lua"] = {
 
 			ENV.discord.sendPrivateMessage = function(content)
 				assert(content, "Content cannot be nil in discord.sendPrivateMessage")
-				assert(message.guild, "Use discord.reply instead of discord.sendPrivateMessage when replying to a DM")
 				if type(content) ~= "table" then
 					content = tostring(content)
 				end


### PR DESCRIPTION
This PR should add the option to run commands in DMs.
At the moment of creating a global command, a new parameter has been added which is `allowDM`, right after `authLevel`. This new parameter has two possible values: 0 or 1.
This also adds a new attribute in new global commands, which is `cmd.dm`. It's either true or false (or nil for old commands, which is treated as false). This attribute can be added in bot commands too.
Due to the lack of `message.member` and `message.guild` in DMs, a few workarounds have been added, assuming that the bot will be in exactly one public guild, and `message.guild` will often be a reference to the guild obtained by `channel["guild"]`. `message.member` is also a reference to the member in this guild.